### PR TITLE
Update auth-twitch.cpp

### DIFF
--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -185,7 +185,7 @@ bool TwitchAuth::LoadInternal()
 
 static const char *ffz_script = "\
 var ffz = document.createElement('script');\
-ffz.setAttribute('src','https://cdn.frankerfacez.com/script/script.min.js');\
+ffz.setAttribute('src','https://cdn2.frankerfacez.com/script/script.min.js');\
 document.head.appendChild(ffz);";
 
 static const char *bttv_script = "\


### PR DESCRIPTION
Due to restrictions by Russian regulators the current link to load the FFZ script no longer works making it non-functional entirely.  
  
The suggested change allows the script to properly load however with partial downsides as certain content will not be used on this and will fail to load for said users.

![image](https://github.com/user-attachments/assets/001a9e90-fab6-4e63-bd82-c4494be65db1)
